### PR TITLE
Keep old format

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -1,4 +1,3 @@
-name: ssoca
 final_name: ssoca
 blobstore:
   provider: s3


### PR DESCRIPTION
fixes:
```
Expected 'name' or 'final_name' but not both in config '/tmp/build/29326b07/ssoca/config/final.yml'

Exit code 1
```